### PR TITLE
fix: improve current path handling in navigation

### DIFF
--- a/src/js/nav.js
+++ b/src/js/nav.js
@@ -5,12 +5,12 @@ document.addEventListener('DOMContentLoaded', function() {
     .split('/')
     .filter(s => s && s.length > 0);
 
-  let currentPath;
-  if (parts.length == 0) {
-    currentPath = 'index.html';
-  } else {
+  let currentPath = '';
+  if (parts.length !== 0) {
     currentPath = parts[parts.length - 1];
   }
+
+  currentPath = currentPath.endsWith('.html') ? currentPath : currentPath + '/index.html';
 
   navLinks.forEach(link => {
     if (link.getAttribute('href').endsWith(currentPath)) {
@@ -23,8 +23,4 @@ document.addEventListener('DOMContentLoaded', function() {
       link.classList.add('active');
     }
   });
-
-  // if (!document.querySelector('.nav-link.active')) {
-  //   navLinks[0].classList.add('active');
-  // }
 });


### PR DESCRIPTION
This pull request includes changes to the `src/js/nav.js` file to improve the handling of the navigation links' active state. The most important changes are focused on simplifying the logic for determining the current path and ensuring the correct link is marked as active.

Improvements to navigation link handling:

* Simplified the logic for setting the `currentPath` by initializing it to an empty string and updating it only if `parts` is not empty. Additionally, ensured `currentPath` ends with `.html` by appending `/index.html` if necessary.
* Removed commented-out code that was no longer needed, making the codebase cleaner and easier to maintain.