### PR TITLE
fix: correct currentPath assignment for navigation links

### DIFF
--- a/src/js/nav.js
+++ b/src/js/nav.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', function() {
     currentPath = parts[parts.length - 1];
   }
 
-  currentPath = currentPath.endsWith('.html') ? currentPath : currentPath + '/index.html';
+  currentPath = currentPath.endsWith('.html') ? currentPath : '/index.html';
 
   navLinks.forEach(link => {
     if (link.getAttribute('href').endsWith(currentPath)) {


### PR DESCRIPTION
This pull request includes a fix to the `src/js/nav.js` file. The change ensures that the `currentPath` variable is correctly set to `/index.html` if it does not end with `.html`.

* [`src/js/nav.js`](diffhunk://#diff-babd9bea0a0bc82b04aa039392478022f073581e1d150991f6c248d8093b889bL13-R13): Modified the `currentPath` assignment to ensure it defaults to `/index.html` when the path does not end with `.html`.